### PR TITLE
Increase MAX_MESSAGE_LENGTH from 250 to 512

### DIFF
--- a/addons/sourcemod/scripting/include/colorlib.inc
+++ b/addons/sourcemod/scripting/include/colorlib.inc
@@ -5,7 +5,7 @@
 
 #include <colorlib_map>
  
-#define MAX_MESSAGE_LENGTH 250
+#define MAX_MESSAGE_LENGTH 345
 
 #define SERVER_INDEX 0
 #define NO_INDEX -1

--- a/addons/sourcemod/scripting/include/colorlib.inc
+++ b/addons/sourcemod/scripting/include/colorlib.inc
@@ -5,7 +5,7 @@
 
 #include <colorlib_map>
  
-#define MAX_MESSAGE_LENGTH 345
+#define MAX_MESSAGE_LENGTH 512
 
 #define SERVER_INDEX 0
 #define NO_INDEX -1


### PR DESCRIPTION
As example:
`SurfTimer | Available Colours: {darkred}darkred {lightred}lightred {red}red {green}green {lime}lime {lightgreen}lightgreen {darkblue}darkblue {lightblue}lightblue {blue}blue {pink}pink {purple}purple {orange}orange {yellow}yellow {grey}grey {grey2}grey2 {default}default`
has 270 chars because of color tags.