### PR TITLE
More Colors extension

### DIFF
--- a/addons/sourcemod/scripting/colorlib_example.sp
+++ b/addons/sourcemod/scripting/colorlib_example.sp
@@ -3,6 +3,7 @@
 
 #include <sourcemod>
 #include <cstrike>
+#define CL_USE_MORE_COLORS
 #include <colorlib>
 
 public void OnPluginStart()

--- a/addons/sourcemod/scripting/colorlib_example.sp
+++ b/addons/sourcemod/scripting/colorlib_example.sp
@@ -3,7 +3,6 @@
 
 #include <sourcemod>
 #include <cstrike>
-#define CL_USE_MORE_COLORS
 #include <colorlib>
 
 public void OnPluginStart()

--- a/addons/sourcemod/scripting/colorlib_morecolors.sp
+++ b/addons/sourcemod/scripting/colorlib_morecolors.sp
@@ -1,0 +1,51 @@
+#pragma semicolon 1
+#pragma newdecls required
+
+#include <sourcemod>
+#define CL_USE_MORE_COLORS
+#include <colorlib>
+
+public void OnPluginStart()
+{
+    RegConsoleCmd("sm_colorlib", Command_ColorLib);
+}
+
+public Action Command_ColorLib(int client, int args)
+{
+    CPrintToChat(client, "CPrintToChat - {#0000AA}%s - {#AA0000}%s", "Test", "Test");
+    CPrintToChatAll("CPrintToChatAll - {#0000AA}%s - {#AA0000}%s", "Test", "Test");
+    CPrintToChatEx(client, client, "CPrintToChatEx - {#0000AA}%s - {#AA0000}%s", "Test", "Test");
+    CPrintToChatAllEx(client, "CPrintToChatAllEx - {#0000AA}%s - {#AA0000}%s", "Test", "Test");
+
+    //CPrintToChatTeam(CS_TEAM_T, "CPrintToTeamEx - {team 1}%s", "Hello Terrorists");
+    //CPrintToChatTeam(CS_TEAM_CT, "CPrintToTeamEx - {team 2}%s", "Hello Counter Terrorist");
+    CPrintToChatTeamEx(GetClientTeam(client), client, "CPrintToTeam - {teamcolor}%N", client);
+
+    CPrintToChatAdmins(ADMFLAG_GENERIC, "CPrintToChatAdmins - {0000FF}%s", "STAAA PLS HELP ME");
+
+    CReplyToCommand(client, "CReplyToCommand - {#0000AA}%s - {#AA0000}%s", "Test", "Test");
+    CReplyToCommandEx(client, client, "CReplyToCommandEx - {#0000AA}%s - {#AA0000}%s", "Test", "Test");
+
+    CShowActivity(client, "Command_ColorLib Usage: %s", "{FF0000}CShowActivity");
+    CShowActivity2(client, "{00FF00}[ColorLib]", "Command_ColorLib Usage: %s", "{FF0000}CShowActivity2");
+    CShowActivityEx(client, "{00FF00}[ColorLib]", "Command_ColorLib Usage: %s", "{FF0000}CShowActivityEx");
+
+    CPrintToServer("CPrintToServer - {#0000AA}%s - {#AA0000}%s", "Test", "Test");
+
+    CSayText2(client, client, "{teamcolor}Hello");
+
+    // Remove Escape codes test
+    char buffer[MAX_MESSAGE_LENGTH];
+    Format(buffer, sizeof(buffer), "{0000FF}Hello {00FF00}World");
+    CFormat(buffer, sizeof(buffer));
+    CRemoveColors(buffer, sizeof(buffer));
+    CPrintToChat(client, buffer);
+
+    // Remove Tags test
+    Format(buffer, sizeof(buffer), "Hello World");
+    CRemoveTags(buffer, sizeof(buffer));
+    CPrintToChat(client, buffer);
+
+    // Dont replace invalid Tags test
+    CPrintToChat(client, "{bad tags here}Hel{#FF}lo {00FF00}World");
+}

--- a/addons/sourcemod/scripting/include/colorlib.inc
+++ b/addons/sourcemod/scripting/include/colorlib.inc
@@ -11,7 +11,7 @@
 #define NO_INDEX -1
 #define NO_PLAYER -2
 
-enum _CL_ProtoBuff
+enum _CL_FeatureStatus
 {
     NotChecked = -1,
     DoesNotSupport = 0,
@@ -19,7 +19,10 @@ enum _CL_ProtoBuff
 }
 
 /* CL_Colors' properties */
-_CL_ProtoBuff _CL_proto_buff_support = NotChecked;
+#if defined CL_USE_MORE_COLORS
+_CL_FeatureStatus _CL_more_colors_support = NotChecked;
+#endif
+_CL_FeatureStatus _CL_proto_buff_support = NotChecked;
 bool _CL_skip_list[MAXPLAYERS + 1] = { false, ... };
 
 /**
@@ -558,28 +561,67 @@ stock void CFormat(char[] message, int maxlength)
             int ret_index = i;
 
             ++i;
-            char color[16];
-            for (int icolor = 0; icolor < sizeof(color); ++icolor)
+            #if defined CL_USE_MORE_COLORS
+            if (message[i] == '#')
             {
-                if (message[i] == '}')
+                // handle hex color
+
+                // first check for valid length
+                // use a buffer for cc here as to not currupt an invalid hex
+                // string by placing the color code over it.
+                char cc[4];
+                if (_CL_SupportsMoreColors() && // check for support here to
+                    message[i + 7] == '}' &&    // avoid color lookup
+                    _CL_GetHexColor(message[i + 1], cc))
                 {
-                    break;
+                    // copy color code
+                    message[i + 1] = cc[0];
+                    message[i + 2] = cc[1];
+                    message[i + 3] = cc[2];
+                    message[i + 4] = cc[3];
+
+                    // skip over cc
+                    i += 7;
+                    index += 3;
                 }
-
-                color[icolor] = message[i];
-                ++i;
-            }
-
-            char cc = view_as<char>(_CL_ColorMap(color));
-            if (cc)
-            {
-                message[index] = cc;
+                else
+                {
+                    // invalid hex tag return to the start index
+                    message[index] = '{';
+                    i = ret_index;
+                }
             }
             else
             {
-                message[index] = '{';
-                i = ret_index;
+            #endif
+                // handle normal color
+                char color[16];
+                for (int icolor = 0; icolor < sizeof(color); ++icolor)
+                {
+                    if (message[i] == '}')
+                    {
+                        break;
+                    }
+
+                    color[icolor] = message[i];
+                    ++i;
+                }
+
+                char cc = view_as<char>(_CL_ColorMap(color));
+                // check if the color code was valid
+                if (cc)
+                {
+                    message[index] = cc;
+                }
+                else
+                {
+                    // on a invalid color code return to the start index
+                    message[index] = '{';
+                    i = ret_index;
+                }
+            #if defined CL_USE_MORE_COLORS
             }
+            #endif
 
             ++index;
         }
@@ -592,6 +634,23 @@ stock void CFormat(char[] message, int maxlength)
 
     message[index] = 0x00;
 }
+
+#if defined CL_USE_MORE_COLORS
+/**
+ * Checks for ProtoBuff support for CSayText2.
+ *
+ * @return          No return.
+ */
+stock bool _CL_SupportsMoreColors()
+{
+    if (_CL_more_colors_support == NotChecked)
+    {
+        _CL_more_colors_support = _CL_IsSource2009() ? Supports : DoesNotSupport;
+    }
+
+    return _CL_more_colors_support == Supports;
+}
+#endif
 
 /**
  * Checks for ProtoBuff support for CSayText2.
@@ -658,3 +717,77 @@ stock void _CL_SendChatMessage(int client, int author, char[] message)
         PrintToChat(client, message);
     }
 }
+
+#if defined CL_USE_MORE_COLORS
+stock bool _CL_IsSource2009()
+{
+    if (GetEngineVersion() == Engine_CSS || GetEngineVersion() == Engine_HL2DM || GetEngineVersion() == Engine_DODS || GetEngineVersion() == Engine_TF2)
+    {
+        return true;
+    }
+
+    return false;
+}
+
+stock int _CL_Get4BitFromHex(const char hex)
+{
+    char h = hex;
+    if (h >= '0' && h <= '9')
+    {
+        return h - '0';
+    }
+    else if (h >= 'A' && h <= 'F')
+    {
+        return h - 'A';
+    }
+    else if (h >= 'a' && h <= 'f')
+    {
+        return h - 'a';
+    }
+
+    return -1;
+}
+
+stock int _CL_GetByteFromHex(const char[] hex)
+{
+    int byte = 0;
+    int ret = _CL_Get4BitFromHex(hex[0]);
+    if (!ret)
+        return -1;
+
+    byte = ret << 4;
+
+    ret = _CL_Get4BitFromHex(hex[1]);
+    if (!ret)
+        return -1;
+
+    return byte | ret;
+}
+
+stock bool _CL_GetHexColor(const char[] hex, char cc[4])
+{
+    // escape code
+    cc[0] = 0x07;
+
+    // red byte
+    int ret = _CL_GetByteFromHex(hex);
+    if (!ret)
+        return false;
+    
+    cc[1] = ret;
+
+    // green byte
+    ret = _CL_GetByteFromHex(hex[2]);
+    if (!ret)
+        return false;
+    
+    cc[2] = ret;
+
+    // blue byte
+    ret = _CL_GetByteFromHex(hex[4]);
+    if (!ret)
+        return false;
+    
+    cc[3] = ret;
+}
+#endif

--- a/addons/sourcemod/scripting/include/colorlib.inc
+++ b/addons/sourcemod/scripting/include/colorlib.inc
@@ -789,5 +789,7 @@ stock bool _CL_GetHexColor(const char[] hex, char cc[4])
         return false;
     
     cc[3] = ret;
+
+    return true;
 }
 #endif


### PR DESCRIPTION
This should add support for the extended colors supported in older source games such as CS:S and TF2.

This currently only supports using hex code tags in the form of `{#RRGGBB}` for example for a dark red you would use `{#AA0000}`.

Named colors are not currently supported by this, by default this extension is disabled and may be used in a plugin by defining `CL_USE_MORE_COLORS` before inclusion see the example plugin for more details.